### PR TITLE
Fixed sorting of effects sprites

### DIFF
--- a/PanzerChasm/client/map_drawers_common.cpp
+++ b/PanzerChasm/client/map_drawers_common.cpp
@@ -25,7 +25,7 @@ void SortEffectsSprites(
 		{
 			const m_Vec3 dir_a= camera_position - a->pos;
 			const m_Vec3 dir_b= camera_position - b->pos;
-			return dir_a.SquareLength() >= dir_b.SquareLength();
+			return dir_a.SquareLength() > dir_b.SquareLength();
 		});
 }
 


### PR DESCRIPTION
Comparison function for `std::sort()` violated strict weak ordering relation leading to undefined behavior
Regular crashes were encountered after weapon shooting