### PR TITLE
Fixed a few repetitive compilation warnings

### DIFF
--- a/PanzerChasm/client/fwd.hpp
+++ b/PanzerChasm/client/fwd.hpp
@@ -4,11 +4,11 @@
 namespace PanzerChasm
 {
 
-struct MapState;
-struct MinimapState;
-struct WeaponState;
+class MapState;
+class MinimapState;
+class WeaponState;
 
-struct MapBSPTree;
+class MapBSPTree;
 
 class CutscenePlayer;
 class MovementController;


### PR DESCRIPTION
Forward declarations are struct's but definitions are classes