### PR TITLE
screenshot and remappable keys function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,9 +24,29 @@ csm.bin
 CSM.BIN
 CSM.bin
 csm.BIN
+CURSED/
+CURSED/*
+cursed/
+cursed/*
+MUSIC/
+MUSIC/*
+music/
+music/*
+ADDON1/
+ADDON1/*
+addon1/
+addon1/*
+borough/
+borough/*
+BOROUGH/
+BOROUGH/*
 
 # Game saves
 saves/*
+
+# Screen shots
+*.tga
+*.TGA
 
 # Build system
 CMakeFiles/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,8 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 find_package(SDL2 REQUIRED)
 
 include_directories(${SDL2_INCLUDE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}
-	${CMAKE_CURRENT_SOURCE_DIR}/src/ ${CMAKE_CURRENT_SOURCE_DIR}/src/panzer_ogl_lib)
+	${CMAKE_CURRENT_SOURCE_DIR}/src/
+	${CMAKE_CURRENT_SOURCE_DIR}/src/panzer_ogl_lib)
 
 # Source and header files
 file(GLOB_RECURSE CHASM_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -52,15 +52,20 @@ the command option `--csm` strings, for example:
 
 `./PanzerChasm --csm CSM_RUS.BIN`
 
-To run the add-on, you must additionally specify the path to it through the 
-parameter command line `--addon`, for example:
-
-`./PanzerChasm --addon ADDON1`
-
 In order to execute some console command at start, use `--exec` option, for example:
 
  `./PanzerChasm --exec "load saves/save_00.pcs"` to start game and immediately load first saved game.
 
+#### Available add-ons:
+
+* Chasm - The Shadow Zone: ADDON1
+* Chasm - Cursed Land    : cursed
+* Chasm - Grim Borough   : borough
+
+To run the add-on, you must additionally specify the path to it through the 
+parameter command line `--addon` or `-addon`, for example:
+
+`./PanzerChasm --addon ADDON1`
 
 #### Control
 

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -16,7 +16,7 @@
 #include "i_hud_drawer.hpp"
 #include "i_map_drawer.hpp"
 #include "i_minimap_drawer.hpp"
-
+#include "../key_checker.hpp"
 #include "client.hpp"
 
 namespace PanzerChasm
@@ -222,36 +222,30 @@ void Client::ProcessEvents( const SystemEvents& events )
 				event.event.mouse_move.dx );
 		}
 
-		// Select weapon.
-		if( event.type == SystemEvent::Type::Wheel && event.event.wheel.delta != 0 )
+		if( event.type == SystemEvent::Type::Key || event.type == SystemEvent::Type::MouseKey || event.type == SystemEvent::Type::Wheel)
 		{
-			if(event.event.wheel.delta > 0) TrySwitchWeaponNext();
-			if(event.event.wheel.delta < 0) TrySwitchWeaponPrevious();
-		}
+			const KeyChecker key_pressed( settings_, event );
 
-		if( event.type == SystemEvent::Type::MouseKey &&
-                    event.event.mouse_key.mouse_button == SystemEvent::MouseKeyEvent::Button::Middle )
-		{
-		    TrySwitchWeaponNext();
-		}
-
-		if( event.type == SystemEvent::Type::Key && event.event.key.pressed )
-		{
-			if( event.event.key.key_code >= KeyCode::K1 &&
-				static_cast<unsigned int>(event.event.key.key_code) < static_cast<unsigned int>(KeyCode::K1) + GameConstants::weapon_count )
+			if( key_pressed( SettingsKeys::key_weapon_next, KeyCode::MouseWheelDown ) ) TrySwitchWeaponNext();
+			if( key_pressed( SettingsKeys::key_weapon_prev, KeyCode::MouseWheelUp ) ) TrySwitchWeaponPrevious();
+			if( key_pressed( SettingsKeys::key_weapon_change, KeyCode::Mouse3 ) ) TrySwitchWeaponNext();
+			if( key_pressed( SettingsKeys::key_weapon_1, KeyCode::K1 ) ||
+			    key_pressed( SettingsKeys::key_weapon_2, KeyCode::K2 ) ||
+			    key_pressed( SettingsKeys::key_weapon_3, KeyCode::K3 ) ||
+			    key_pressed( SettingsKeys::key_weapon_4, KeyCode::K4 ) ||
+			    key_pressed( SettingsKeys::key_weapon_5, KeyCode::K5 ) ||
+			    key_pressed( SettingsKeys::key_weapon_6, KeyCode::K6 ) ||
+			    key_pressed( SettingsKeys::key_weapon_7, KeyCode::K7 ) ||
+			    key_pressed( SettingsKeys::key_weapon_8, KeyCode::K8 ) ||
+			    key_pressed( SettingsKeys::key_weapon_9, KeyCode::K9 ) )
 			{
 				unsigned int weapon_index=static_cast<unsigned int>( event.event.key.key_code ) - static_cast<unsigned int>( KeyCode::K1 );
 				if( player_state_.ammo[ weapon_index ] > 0u && ( player_state_.weapons_mask & (1u << weapon_index) ) != 0u )
 					requested_weapon_index_= weapon_index;
 			}
-
-			if( event.event.key.key_code == KeyCode::Tab )
-				minimap_mode_= !minimap_mode_;
-
-			if( event.event.key.key_code == KeyCode::Minus )
-				settings_.SetSetting( g_small_hud_mode, false );
-			if( event.event.key.key_code == KeyCode::Equals )
-				settings_.SetSetting( g_small_hud_mode, true );
+			if( key_pressed( SettingsKeys::key_minimap, KeyCode::Tab ) ) minimap_mode_= !minimap_mode_;
+			if( key_pressed( SettingsKeys::key_small_hud_off, KeyCode::Minus ) ) settings_.SetSetting( g_small_hud_mode, false );
+			if( key_pressed( SettingsKeys::key_small_hud_on, KeyCode::Equals ) ) settings_.SetSetting( g_small_hud_mode, true );
 		}
 	} // for events
 }
@@ -259,6 +253,7 @@ void Client::ProcessEvents( const SystemEvents& events )
 void Client::Loop( const InputState& input_state, const bool paused )
 {
 	const Time current_real_time= Time::CurrentTime();
+	const KeyChecker key_pressed( settings_, input_state );
 
 	// Calculate time, which we spend in pause.
 	// Subtract time, spended in pauses, from real time.
@@ -306,14 +301,16 @@ void Client::Loop( const InputState& input_state, const bool paused )
 
 	{ // Scale minimap.
 		const float log2_delta= 2.0f * tick_dt_s;
-		if( input_state.keyboard[ static_cast<unsigned int>( SystemEvent::KeyEvent::KeyCode::SquareBrackretLeft ) ] )
+		
+		if( key_pressed( SettingsKeys::key_minimap_scale_dec, KeyCode::SquareBracketLeft ) )
 			minimap_scale_log2_-= log2_delta;
-		if( input_state.keyboard[ static_cast<unsigned int>( SystemEvent::KeyEvent::KeyCode::SquareBrackretRight ) ] )
+		if( key_pressed( SettingsKeys::key_minimap_scale_inc, KeyCode::SquareBracketRight ) )
 			minimap_scale_log2_+= log2_delta;
+
 		minimap_scale_log2_= std::max( -2.0f, std::min( minimap_scale_log2_, 1.0f ) );
 	}
 
-	camera_controller_.Tick( input_state.keyboard );
+	camera_controller_.Tick( input_state );
 
 	if( sound_engine_ != nullptr )
 	{
@@ -355,17 +352,17 @@ void Client::Loop( const InputState& input_state, const bool paused )
 		}
 		{ // Send move message
 			float move_direction, move_acceleration;
-			camera_controller_.GetAcceleration( input_state.keyboard, move_direction, move_acceleration );
+			camera_controller_.GetAcceleration( input_state, move_direction, move_acceleration );
 
 			Messages::PlayerMove message;
 			message.view_direction   = AngleToMessageAngle( camera_controller_.GetViewAngleZ() + Constants::half_pi );
 			message.move_direction   = AngleToMessageAngle( move_direction );
 			message.acceleration     = static_cast<unsigned char>( move_acceleration * 254.5f );
-			message.jump_pressed     = input_state.mouse[ static_cast<unsigned int>( SystemEvent::MouseKeyEvent::Button::Right ) ] || camera_controller_.JumpPressed();
+			message.jump_pressed     = key_pressed( SettingsKeys::key_jump, KeyCode::Mouse2 ) || camera_controller_.JumpPressed();
 			message.weapon_index     = requested_weapon_index_;
 			message.view_dir_angle_x = AngleToMessageAngle( camera_controller_.GetViewAngleX() );
 			message.view_dir_angle_z = AngleToMessageAngle( camera_controller_.GetViewAngleZ() );
-			message.shoot_pressed    = input_state.mouse[ static_cast<unsigned int>( SystemEvent::MouseKeyEvent::Button::Left ) ];
+			message.shoot_pressed    = key_pressed( SettingsKeys::key_fire, KeyCode::Mouse1 );
 			message.color            = settings_.GetOrSetInt( SettingsKeys::player_color );
 			connection_info_->messages_sender.SendUnreliableMessage( message );
 		}

--- a/src/client/movement_controller.hpp
+++ b/src/client/movement_controller.hpp
@@ -25,12 +25,12 @@ public:
 	void SetAspect( float aspect );
 
 	void UpdateParams();
-	void Tick( const KeyboardState& keyboard_state );
+	void Tick( const InputState& input_state_ );
 	void SetSpeed( float speed );
 	void SetAngles( float z_angle, float x_angle );
 
 	void GetAcceleration(
-		const KeyboardState& keyboard_state,
+		const InputState& input_state,
 		float& out_dir, float& out_acceleration ) const;
 
 	float GetEyeZShift() const;
@@ -65,7 +65,8 @@ private:
 	float speed_;
 
 	bool jump_pressed_;
-
+	bool mouse_look_pressed_;
+	bool mouse_look_;
 	const Time start_tick_;
 	Time prev_calc_tick_;
 

--- a/src/common/files.cpp
+++ b/src/common/files.cpp
@@ -1,4 +1,5 @@
 #include "files.hpp"
+#include <cstring>
 
 namespace ChasmReverse
 {
@@ -31,5 +32,23 @@ void FileWrite( std::FILE* const file, const void* buffer, const unsigned int si
 	} while( write_total < size );
 }
 
+const char* ExtractExtension( const char* const file_path )
+{
+	unsigned int pos= std::strlen( file_path );
+
+	while( pos > 0u && file_path[ pos ] != '.' )
+		pos--;
+
+	return file_path + pos + 1u;
+}
 
 } // namespace ChasmReverse
+
+bool create_directory(const std::string& directory)
+{
+#ifdef _WIN32
+	return (_mkdir( directory.c_str() ) == 0 ? true : false);
+#else
+	return (mkdir( directory.c_str(), 0777 ) == 0 ? true : false);
+#endif
+}

--- a/src/common/files.hpp
+++ b/src/common/files.hpp
@@ -1,10 +1,48 @@
 #pragma once
 #include <cstdio>
+#include <string>
+// Include OS-dependend stuff for "mkdir".
+#ifdef _WIN32
+#include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 
 namespace ChasmReverse
 {
 
 void FileRead( std::FILE* const file, void* buffer, const unsigned int size );
 void FileWrite( std::FILE* const file, const void* buffer, const unsigned int size );
+const char* ExtractExtension( const char* const file_path );
+
 
 } // namespace ChasmReverse
+
+template<class T>
+T dir_name(T const& path, T const& delims = "/\\")
+{
+	return path.substr(0, path.find_last_of(delims));
+}
+
+template<class T>
+T base_name(T const& path, T const& delims = "/\\")
+{
+	return path.substr(path.find_last_of(delims) + 1);
+}
+
+template<class T>
+T remove_extension(T const& filename)
+{
+	typename T::size_type const p(base_name<std::string>(filename).find_last_of('.'));
+	return ((p > 0 && p != T::npos) ? dir_name<std::string>(filename) + "/" + base_name<std::string>(filename).substr(0, p) : filename);
+}
+
+template<class T>
+T extract_extension(T const& filename)
+{
+	typename T::size_type const p(base_name<std::string>(filename).find_last_of('.'));
+	return ((p > 0 && p != T::npos) ? dir_name<std::string>(filename) + "/" + base_name<std::string>(filename).substr(p, T::npos) : filename);
+}
+
+bool create_directory(const std::string& directory);

--- a/src/common/tga.cpp
+++ b/src/common/tga.cpp
@@ -3,6 +3,10 @@
 #include "files.hpp"
 
 #include "tga.hpp"
+#include <vector>
+#include <array>
+#include <cstdint>
+#include <cstring>
 
 namespace ChasmReverse
 {
@@ -36,14 +40,19 @@ void WriteTGA(
 	const unsigned char* const palette,
 	const char* const file_name )
 {
+	std::vector<std::array<uint8_t, 4>> pixels(width * height);
+	size_t i = 0;
+	for(auto & p : pixels)
+		p = { data[ i * 4 + 2 ], data[ i * 4 + 1 ], data[ i * 4 + 0 ], data[ i++ * 4 + 3 ] };
+
 	TGAHeader tga;
 
 	tga.id_length= 0;
-	tga.colormap_type= 1; // image with colormap
-	tga.image_type= 1; // image with palette without compression
+	tga.colormap_type= (palette == nullptr) ? 0 : 1; // image with/out colormap
+	tga.image_type= (palette == nullptr) ? 2 : 1; // image with/out palette without compression
 
 	tga.colormap_index= 0;
-	tga.colormap_length= 256;
+	tga.colormap_length= (palette == nullptr) ? 256 : 0;
 	tga.colormap_size= 32;
 
 	tga.x_origin= 0;
@@ -51,8 +60,8 @@ void WriteTGA(
 	tga.width = width ;
 	tga.height= height;
 
-	tga.pixel_bits= 8;
-	tga.attributes= 1 << 5; // vertical flip flag
+	tga.pixel_bits= (palette == nullptr) ? 32 : 8;
+	tga.attributes= (palette == nullptr) ? 0 : 1 << 5; // vertical flip flag
 	tga.attributes|= 8; // bits in alpha-channell
 
 	std::FILE* file= std::fopen( file_name, "wb" );
@@ -63,20 +72,24 @@ void WriteTGA(
 	}
 
 	FileWrite( file, &tga, sizeof(tga) );
+//	FileWrite( file, file_name, strlen(file_name) );
 
-	unsigned char palette_rb_swapped[ 256 * 4 ];
-	for( unsigned int i= 0; i < 256; i++ )
+	if(palette != nullptr)
 	{
-		palette_rb_swapped[ i * 4 + 0 ]= palette[ i * 3 + 2 ];
-		palette_rb_swapped[ i * 4 + 1 ]= palette[ i * 3 + 1 ];
-		palette_rb_swapped[ i * 4 + 2 ]= palette[ i * 3 + 0 ];
-		palette_rb_swapped[ i * 4 + 3 ]= 255;
+		unsigned char palette_rb_swapped[ 256 * 4 ];
+		for( unsigned int i= 0; i < 256; i++ )
+		{
+			palette_rb_swapped[ i * 4 + 0 ]= palette[ i * 3 + 2 ];
+			palette_rb_swapped[ i * 4 + 1 ]= palette[ i * 3 + 1 ];
+			palette_rb_swapped[ i * 4 + 2 ]= palette[ i * 3 + 0 ];
+			palette_rb_swapped[ i * 4 + 3 ]= 255;
+		}
+		palette_rb_swapped[255 * 4 + 3]= 0;
+
+
+		FileWrite( file, palette_rb_swapped, sizeof(palette_rb_swapped) );
 	}
-	palette_rb_swapped[255 * 4 + 3]= 0;
-
-
-	FileWrite( file, palette_rb_swapped, sizeof(palette_rb_swapped) );
-	FileWrite( file, data, width * height );
+	FileWrite( file, &pixels.front().front(), pixels.size() * sizeof(std::array<uint8_t, 4>) );
 
 	std::fclose( file );
 }

--- a/src/host.cpp
+++ b/src/host.cpp
@@ -15,7 +15,8 @@
 #include "shared_drawers.hpp"
 #include "save_load.hpp"
 #include "sound/sound_engine.hpp"
-
+#include "key_checker.hpp"
+#include "shared_settings_keys.hpp"
 #include "host.hpp"
 
 namespace PanzerChasm
@@ -155,7 +156,6 @@ Host::~Host()
 bool Host::Loop()
 {
 	const Time tick_start_time= Time::CurrentTime();
-
 	// Events processing
 	InputState input_state;
 	if( system_window_ != nullptr )
@@ -164,7 +164,6 @@ bool Host::Loop()
 		system_window_->GetInput( events_ );
 		system_window_->GetInputState( input_state );
 	}
-
 	// Special host key events.
 	for( const SystemEvent& event : events_ )
 	{
@@ -223,6 +222,7 @@ bool Host::Loop()
 			client_->Loop( input_state, really_paused );
 	}
 
+
 	// Draw operations
 	if( system_window_ && !system_window_->IsMinimized() )
 	{
@@ -262,6 +262,10 @@ bool Host::Loop()
 		}
 
 		system_window_->EndFrame();
+
+		const KeyChecker key_pressed( settings_, input_state );
+		if( key_pressed( SettingsKeys::key_screenshot, KeyCode::F12 ) )
+			system_window_->ScreenShot();
 	}
 
 

--- a/src/key_checker.cpp
+++ b/src/key_checker.cpp
@@ -1,0 +1,6 @@
+#include "key_checker.hpp"
+
+namespace PanzerChasm
+{
+
+} // namespace PanzerChasm

--- a/src/key_checker.hpp
+++ b/src/key_checker.hpp
@@ -1,0 +1,64 @@
+#pragma once
+#include <algorithm>
+#include "settings.hpp"
+#include "math_utils.hpp"
+#include "system_event.hpp"
+
+namespace PanzerChasm
+{
+
+using KeyCode= SystemEvent::KeyEvent::KeyCode;
+
+class KeyChecker
+{
+public:
+	KeyChecker( Settings& settings, const InputState& input_state )
+		: settings_(settings), input_state_(input_state), event_(SystemEvent()), event_source_(false)
+	{}
+	KeyChecker( Settings& settings, const SystemEvent& event )
+		: settings_(settings), input_state_(InputState()), event_(event), event_source_(true)
+	{}
+
+	bool operator()( const char* const key_setting_name, const KeyCode default_value ) const
+	{
+		const char32_t key = std::clamp((const char32_t)settings_.GetOrSetInt( key_setting_name, static_cast<int>(default_value)), (const char32_t)KeyCode::Unknown, (const char32_t)KeyCode::KeyCount);
+
+		if(event_source_)
+		{
+			char32_t key_event = KeyCode::Unknown;
+			switch(event_.type)
+			{
+				case SystemEvent::Type::Wheel:
+					if( event_.event.wheel.delta > 0 ) key_event = KeyCode::MouseWheelUp;
+					if( event_.event.wheel.delta < 0 ) key_event = KeyCode::MouseWheelDown;
+					break;
+				case SystemEvent::Type::MouseKey:
+					if( event_.event.mouse_key.pressed )
+						key_event = KeyCode::MouseUnknown + (const char32_t)event_.event.mouse_key.mouse_button;
+					break;
+				case SystemEvent::Type::Key:
+					if( event_.event.key.pressed ) key_event = event_.event.key.key_code;
+					break;
+				default:
+					break;
+			}
+			if( key == std::clamp( key_event, (char32_t)KeyCode::Unknown, (char32_t)KeyCode::KeyCount ) ) return true;
+		}
+		else 
+		{
+			if( key < KeyCode::MouseUnknown)
+				return input_state_.keyboard[ key ];
+			else
+				return input_state_.mouse[ key - KeyCode::MouseUnknown ];
+		}
+		return false;
+	}
+
+private:
+	Settings& settings_;
+	bool event_source_;
+	const InputState& input_state_;
+	const SystemEvent& event_;
+};
+
+} // namespace PanzerChasm

--- a/src/math_utils.hpp
+++ b/src/math_utils.hpp
@@ -36,3 +36,15 @@ float DistanceToLineSegment(
 	const m_Vec2& v1 );
 
 } // namespace PanzerChasm
+
+
+#if __cplusplus < 201703L
+namespace std
+{
+	template<typename Tp_>
+	constexpr inline Tp_ clamp(Tp_ dst, Tp_ lo, Tp_ hi)
+	{
+		return (dst <= hi ? (dst >= lo ? dst : lo) : hi);
+	}
+}
+#endif

--- a/src/save_load.cpp
+++ b/src/save_load.cpp
@@ -1,14 +1,6 @@
 #include <cctype>
 #include <cstring>
 
-// Include OS-dependend stuff for "mkdir".
-#ifdef _WIN32
-#include <direct.h>
-#else
-#include <sys/stat.h>
-#include <sys/types.h>
-#endif
-
 #include "common/files.hpp"
 using namespace ChasmReverse;
 
@@ -189,11 +181,8 @@ void GetSaveFileNameForSlot(
 
 void CreateSlotSavesDir()
 {
-#ifdef _WIN32
-	_mkdir( SAVES_DIR );
-#else
-	mkdir( SAVES_DIR, 0777 );
-#endif
+	if(!create_directory( SAVES_DIR ))
+		Log::Warning("Couldn't create saves directory: ", strerror(errno));
 }
 
 } // namespace PanzerChasm

--- a/src/shared_settings_keys.hpp
+++ b/src/shared_settings_keys.hpp
@@ -9,6 +9,7 @@ namespace SettingsKeys
 const char always_run[]= "sv_always_run";
 const char crosshair[]= "cl_crosshair";
 const char reverse_mouse[]= "in_reverse_mouse";
+const char perm_mlook[]= "in_perm_mlook";
 const char weapon_reset[]= "cl_weapon_reset";
 const char old_style_perspective[]= "cl_old_style_perspective";
 const char player_color[]= "cl_color";
@@ -19,15 +20,48 @@ const char cd_volume[]= "cd_volume";
 const char mouse_sensetivity[]= "cl_mouse_speed";
 const char fov[]= "cl_fov";
 
+/* essential keys */
 const char key_forward[]= "in_key_forward";
 const char key_backward[]= "in_key_backward";
 const char key_step_left[]= "in_key_left";
 const char key_step_right[]= "in_key_right";
+const char key_speed_up[]= "in_key_speed_up";
+const char key_always_run[]= "in_key_always_run";
+const char key_jump[]= "in_key_jump";
+const char key_fire[]= "in_key_fire";
+const char key_weapon_1[]= "in_key_weapon_1";
+const char key_weapon_2[]= "in_key_weapon_2";
+const char key_weapon_3[]= "in_key_weapon_3";
+const char key_weapon_4[]= "in_key_weapon_4";
+const char key_weapon_5[]= "in_key_weapon_5";
+const char key_weapon_6[]= "in_key_weapon_6";
+const char key_weapon_7[]= "in_key_weapon_7";
+const char key_weapon_8[]= "in_key_weapon_8";
+const char key_weapon_9[]= "in_key_weapon_9";
+const char key_minimap[]= "in_key_minimap";
+const char key_minimap_scale_dec[]= "in_key_minimap_scale_dec";
+const char key_minimap_scale_inc[]= "in_key_minimap_scale_inc";
+const char key_small_hud_off[]= "in_key_small_hud_off";
+const char key_small_hud_on[]= "in_key_small_hud_on";
+const char key_weapon_change[]= "in_key_weapon_change";
+const char key_weapon_next[]= "in_key_weapon_next";
+const char key_weapon_prev[]= "in_key_weapon_prev";
+const char key_perm_mlook[]= "in_key_perm_mlook"; 
+const char key_temp_mlook[]= "in_key_temp_mlook"; 
+const char key_strafe_on[]= "in_key_strafe_on";
 const char key_turn_left[]= "in_key_turn_left";
 const char key_turn_right[]= "in_key_turn_right";
 const char key_look_up[]= "in_key_look_up";
+const char key_center_view[]= "in_key_center_view";
 const char key_look_down[]= "in_key_look_down";
-const char key_jump[]= "in_key_jump";
+const char key_load_game[]= "in_key_load_game"; 
+const char key_save_game[]= "in_key_save_game"; 
+const char key_load_menu[]= "in_key_load_menu"; 
+const char key_save_menu[]= "in_key_save_menu"; 
+const char key_options_menu[]= "in_key_options_menu"; 
+const char key_network_menu[]= "in_key_network_menu"; 
+const char key_quit_menu[]= "in_key_quit_menu"; 
+const char key_screenshot[]= "in_key_screenshot"; 
 
 const char window_width []= "r_window_width" ;
 const char window_height[]= "r_window_height";
@@ -36,7 +70,8 @@ const char fullscreen_display[]= "r_fullscreen_display";
 const char fullscreen_width []= "r_fullscreen_width" ;
 const char fullscreen_height[]= "r_fullscreen_height";
 const char fullscreen_frequency[]= "r_fullscreen_frequency";
-
+const char vsync[]= "r_gl_vsync";
+const char draw_fps[]= "cl_draw_fps";
 const char software_rendering[]= "r_software_rendering";
 const char software_scale[]= "r_software_scale";
 
@@ -48,7 +83,6 @@ const char opengl_msaa_level[]= "r_msaa_level";
 
 const char shadows[]= "r_shadows";
 const char brightness[]= "r_brightness";
-
 } // namespace SettingsKeys
 
 } // PanzerChasm

--- a/src/sound/sounds_loader.cpp
+++ b/src/sound/sounds_loader.cpp
@@ -7,6 +7,7 @@
 #include "../vfs.hpp"
 
 #include "sounds_loader.hpp"
+#include "common/files.hpp"
 
 namespace PanzerChasm
 {
@@ -16,16 +17,6 @@ namespace Sound
 
 namespace
 {
-
-const char* ExtractExtension( const char* const file_path )
-{
-	unsigned int pos= std::strlen( file_path );
-
-	while( pos > 0u && file_path[ pos ] != '.' )
-		pos--;
-
-	return file_path + pos + 1u;
-}
 
 class RawPCMSoundData final : public ISoundData
 {
@@ -144,7 +135,7 @@ ISoundDataConstPtr LoadSound( const char* file_path, Vfs& vfs )
 		return nullptr;
 	}
 
-	const char* const extension= ExtractExtension( file_path );
+	const char* const extension= ChasmReverse::ExtractExtension( file_path );
 
 	if( std::strcmp( extension, "WAV" ) == 0 ||
 		std::strcmp( extension, "wav" ) == 0 )

--- a/src/system_event.cpp
+++ b/src/system_event.cpp
@@ -18,6 +18,16 @@ const char* GetKeyName( const SystemEvent::KeyEvent::KeyCode key_code )
 	case KeyCode::Space: return "Space";
 	case KeyCode::Backspace: return "Backspace";
 	case KeyCode::Tab: return "Tab";
+	case KeyCode::CapsLock: return "CapsLock";
+	case KeyCode::LeftControl: return "LControl";
+	case KeyCode::RightControl: return "RControl";
+	case KeyCode::LeftAlt: return "LAlt";
+	case KeyCode::RightAlt: return "RAlt";
+	case KeyCode::LeftShift: return "LShift";
+	case KeyCode::RightShift: return "RShift";
+	case KeyCode::LeftMetaGUI: return "LMetaGUI";
+	case KeyCode::RightMetaGUI: return "RMetaGUI";
+	case KeyCode::Application: return "App";
 
 	case KeyCode::PageUp: return "PageUp";
 	case KeyCode::PageDown: return "PageDown";
@@ -55,7 +65,6 @@ const char* GetKeyName( const SystemEvent::KeyEvent::KeyCode key_code )
 	case KeyCode::Y: return "X";
 	case KeyCode::Z: return "Z";
 
-	case KeyCode::K0: return "0";
 	case KeyCode::K1: return "1";
 	case KeyCode::K2: return "2";
 	case KeyCode::K3: return "3";
@@ -65,12 +74,13 @@ const char* GetKeyName( const SystemEvent::KeyEvent::KeyCode key_code )
 	case KeyCode::K7: return "7";
 	case KeyCode::K8: return "8";
 	case KeyCode::K9: return "9";
+	case KeyCode::K0: return "0";
 
 	case KeyCode::Minus: return "-";
 	case KeyCode::Equals: return "=";
 
-	case KeyCode::SquareBrackretLeft: return "[";
-	case KeyCode::SquareBrackretRight: return "]";
+	case KeyCode::SquareBracketLeft: return "[";
+	case KeyCode::SquareBracketRight: return "]";
 
 	case KeyCode::Semicolon: return ";";
 	case KeyCode::Apostrophe: return "'";
@@ -93,7 +103,35 @@ const char* GetKeyName( const SystemEvent::KeyEvent::KeyCode key_code )
 	case KeyCode::F11: return "F11";
 	case KeyCode::F12: return "F12";
 
+	case KeyCode::KPDivide: return "KPDivide";
+	case KeyCode::KPMultiply: return "KPMultiply";
+	case KeyCode::KPMinus: return "KPMinus";
+	case KeyCode::KPPlus: return "KPPlus";
+	case KeyCode::KPEnter: return "KPEnter";
+	case KeyCode::KP1: return "KP1";
+	case KeyCode::KP2: return "KP2";
+	case KeyCode::KP3: return "KP3";
+	case KeyCode::KP4: return "KP4";
+	case KeyCode::KP5: return "KP5";
+	case KeyCode::KP6: return "KP6";
+	case KeyCode::KP7: return "KP7";
+	case KeyCode::KP8: return "KP8";
+	case KeyCode::KP9: return "KP9";
+	case KeyCode::KP0: return "KP0";
+	case KeyCode::KPPeriod: return "KPPeriod";
+
 	case KeyCode::Pause: return "Pause";
+
+	case KeyCode::MouseUnknown: return "MUnknown";
+	case KeyCode::Mouse1: return "Mouse1";
+	case KeyCode::Mouse2: return "Mouse2";
+	case KeyCode::Mouse3: return "Mouse3";
+	case KeyCode::Mouse4: return "Mouse4";
+	case KeyCode::Mouse5: return "Mouse5";
+	case KeyCode::Mouse6: return "Mouse6";
+	case KeyCode::MouseWheelUp: return "MWheelUp";
+	case KeyCode::MouseWheelDown: return "MWheelDn";
+
 	};
 
 	PC_ASSERT(false);
@@ -105,8 +143,7 @@ bool KeyCanBeUsedForControl( const SystemEvent::KeyEvent::KeyCode key_code )
 	using KeyCode= SystemEvent::KeyEvent::KeyCode;
 	switch( key_code )
 	{
-	case KeyCode::Enter:
-	case KeyCode::Space:
+	case KeyCode::Unknown:
 
 	case KeyCode::PageUp:
 	case KeyCode::PageDown:
@@ -144,20 +181,6 @@ bool KeyCanBeUsedForControl( const SystemEvent::KeyEvent::KeyCode key_code )
 	case KeyCode::Y:
 	case KeyCode::Z:
 
-	case KeyCode::Semicolon:
-	case KeyCode::Apostrophe:
-	case KeyCode::BackSlash:
-	case KeyCode::Comma:
-	case KeyCode::Period:
-	case KeyCode::Slash:
-
-		return true;
-
-	case KeyCode::Escape: // menu navigation key
-	case KeyCode::Backspace:
-	case KeyCode::Tab: // minimap
-
-	case KeyCode::K0: // Numbers keys used for weapon select
 	case KeyCode::K1:
 	case KeyCode::K2:
 	case KeyCode::K3:
@@ -167,11 +190,61 @@ bool KeyCanBeUsedForControl( const SystemEvent::KeyEvent::KeyCode key_code )
 	case KeyCode::K7:
 	case KeyCode::K8:
 	case KeyCode::K9:
+	case KeyCode::K0: // Numbers keys used for weapon select
 
+	case KeyCode::Semicolon:
+	case KeyCode::Apostrophe:
+	case KeyCode::BackSlash:
+	case KeyCode::Comma:
+	case KeyCode::Period:
+	case KeyCode::Slash:
+	case KeyCode::SquareBracketLeft: // [ and ] used for map scaling
+	case KeyCode::SquareBracketRight:
+	case KeyCode::Enter:
+	case KeyCode::Space:
+	case KeyCode::Tab: // minimap
+	case KeyCode::CapsLock:
+	case KeyCode::LeftControl:
+	case KeyCode::RightControl:
+	case KeyCode::LeftAlt:
+	case KeyCode::RightAlt:
+	case KeyCode::LeftShift:
+	case KeyCode::RightShift:
+	case KeyCode::LeftMetaGUI:  // menu back
+	case KeyCode::RightMetaGUI: // menu select
+	case KeyCode::Application:
+
+	case KeyCode::MouseUnknown:
+	case KeyCode::Mouse1:
+	case KeyCode::Mouse2:
+	case KeyCode::Mouse3:
+	case KeyCode::Mouse4:
+	case KeyCode::Mouse5:
+	case KeyCode::Mouse6:
+	case KeyCode::MouseWheelUp:
+	case KeyCode::MouseWheelDown:
+	case KeyCode::KeyCount:
+	case KeyCode::Escape:   // menu navigation key
+	case KeyCode::Backspace: // clear entrance
+	case KeyCode::KPDivide:
+	case KeyCode::KPMultiply:
+	case KeyCode::KPMinus:
+	case KeyCode::KPPlus:
+	case KeyCode::KPEnter:
+	case KeyCode::KP1:
+	case KeyCode::KP2:
+	case KeyCode::KP3:
+	case KeyCode::KP4:
+	case KeyCode::KP5:
+	case KeyCode::KP6:
+	case KeyCode::KP7:
+	case KeyCode::KP8:
+	case KeyCode::KP9:
+	case KeyCode::KP0:
+	case KeyCode::KPPeriod:
+		return true;
 	case KeyCode::Minus: // +- used for hud scaling
 	case KeyCode::Equals:
-	case KeyCode::SquareBrackretLeft: // [ and ] used for map scaling
-	case KeyCode::SquareBrackretRight:
 
 	case KeyCode::F1: // Functional keys used for quick commands
 	case KeyCode::F2:
@@ -188,8 +261,6 @@ bool KeyCanBeUsedForControl( const SystemEvent::KeyEvent::KeyCode key_code )
 
 	case KeyCode::Pause: // Pause key used for pause (C.O.)
 
-	case KeyCode::Unknown:
-	case KeyCode::KeyCount:
 
 		return false;
 	};

--- a/src/system_event.hpp
+++ b/src/system_event.hpp
@@ -19,7 +19,7 @@ struct SystemEvent
 
 	struct KeyEvent
 	{
-		enum class KeyCode
+		enum KeyCode : char32_t
 		{
 			// Do not set here key names manually.
 			Unknown= 0,
@@ -40,29 +40,45 @@ struct SystemEvent
 			BackQuote,
 
 			A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z,
-			K0, K1, K2, K3, K4, K5, K6, K7, K8, K9,
+			K1, K2, K3, K4, K5, K6, K7, K8, K9, K0,
 
 			// Put new keys at back.
 			Minus, Equals,
-			SquareBrackretLeft, SquareBrackretRight,
+			SquareBracketLeft, SquareBracketRight,
 			Semicolon, Apostrophe, BackSlash,
 			Comma, Period, Slash,
 
 			F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12,
 
+			KPDivide, KPMultiply, KPMinus, KPPlus, KPEnter,
+			KP1, KP2, KP3, KP4, KP5, KP6, KP7, KP8, KP9, KP0, KPPeriod,
+
 			Pause,
+			CapsLock,
+			LeftControl,
+			RightControl,
+			LeftAlt,
+			RightAlt,
+			LeftShift,
+			RightShift,
+			LeftMetaGUI,
+			RightMetaGUI,
+			Application,
+
+			MouseUnknown, Mouse1, Mouse2, Mouse3, Mouse4, Mouse5, Mouse6,
+			MouseWheelUp, MouseWheelDown,
 			// Put it last here.
 			KeyCount
 		};
 
-		enum Modifiers : unsigned int
+		enum Modifiers : char32_t
 		{
 			Shift= 0x01u,
 			Control= 0x02u,
 			Alt= 0x04u,
 			Caps= 0x08u,
 		};
-		typedef unsigned int ModifiersMask;
+		typedef char32_t ModifiersMask;
 
 		KeyCode key_code;
 		ModifiersMask modifiers;
@@ -76,10 +92,17 @@ struct SystemEvent
 
 	struct MouseKeyEvent
 	{
-		enum class Button
+		enum Button : char32_t
 		{
 			Unknown= 0,
-			Left, Right, Middle,
+			Left=1, Mouse1=1,
+			Right=2, Mouse2=2,
+			Middle=3, Mouse3=3,
+			Mouse4=4,
+			Mouse5=5,
+			Mouse6=6,
+			MouseWheelUp=7,
+			MouseWheelDown=8,
 			ButtonCount
 		};
 

--- a/src/system_window.hpp
+++ b/src/system_window.hpp
@@ -44,6 +44,7 @@ public:
 	void GetInput( SystemEvents& out_events );
 	void GetInputState( InputState& out_input_state );
 	void CaptureMouse( bool need_capture );
+	bool ScreenShot( const std::string& file = "screenshot" ) const;
 
 private:
 	struct PixelColorsOrder
@@ -64,6 +65,7 @@ private:
 	Size2 viewport_size_; // Inner viewport size, not system window size.
 
 	SDL_Window* window_= nullptr;
+	SDL_Renderer* renderer_= nullptr;
 	SDL_GLContext gl_context_= nullptr; // If not null - current mode is OpenGL, else - software.
 	bool use_gl_context_for_software_renderer_= false;
 	unsigned int software_renderer_gl_texture_= ~0u;


### PR DESCRIPTION
- switch from KeyboardState to InputState allowing other input device type states
- use char32_t instead of unsigned int for KeyCode
- add remappable keys present in original portable release like center_view and weapon_next/prev
- allow mouse control remap
- allow rotate/wrap for msaa and pixel_size
- fix character input in window resolution video menu
- add file path string functions for C++ < 17
- modify WriteTGA to support RGBA32 flipped input if palette equals nullptr
- add SystemEvent support to KeyChecker
- add screenshot implementation #49
- add LICENSE
- add add-on list in README.md

**TODO:**
- KeyChecker InputState mouse wheel support (only SystemEvent works atm)
- multiple exclusion key event map
- allow list of input device types to be mapped