### PR TITLE
MacOS simple support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,13 @@ if(WIN32)
 	set(CHASM_RESOURCES
 		res/PanzerChasm.rc
 	)
+elseif(APPLE)
+	find_package(OpenGL REQUIRED)
+	include_directories(${OPENGL_INCLUDE_DIR})
+	set(CHASM_LIBS
+		${CHASM_LIBS}
+		${OPENGL_LIBRARIES}
+	)
 else()
 	set(CHASM_LIBS
 		${CHASM_LIBS}

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -43,7 +43,7 @@ void MessagePositionToPosition( const Messages::CoordType* pos, m_Vec3& out_pos 
 
 Messages::AngleType AngleToMessageAngle( const float angle )
 {
-	return static_cast<Messages::AngleType>( angle * 65536.0f / Constants::two_pi );
+	return static_cast<Messages::AngleType>( NormalizeAngle( angle ) * 65536.0f / Constants::two_pi );
 }
 
 float MessageAngleToAngle( const Messages::AngleType angle )

--- a/src/system_window.cpp
+++ b/src/system_window.cpp
@@ -256,9 +256,9 @@ windowed:
 	viewport_size_.Width ()= static_cast<unsigned int>( width  / scale );
 	viewport_size_.Height()= static_cast<unsigned int>( height / scale );
 
-    #ifndef __APPLE__
+	#ifndef __APPLE__
 	use_gl_context_for_software_renderer_= !is_opengl && settings_.GetOrSetBool( "r_software_use_gl_screen_update", true );
-    #endif
+	#endif
     if( is_opengl )
 	{
 		SDL_GL_SetAttribute( SDL_GL_DOUBLEBUFFER, 1 );
@@ -350,9 +350,9 @@ windowed:
 
 	if( is_opengl )
 	{
-        #ifndef __APPLE__
+		#ifndef __APPLE__
 		GetGLFunctions( SDL_GL_GetProcAddress );
-        #endif
+		#endif
 
 		#ifdef DEBUG
 		// Do reinterpret_cast, because on different platforms arguments of GLDEBUGPROC have
@@ -572,14 +572,14 @@ void SystemWindow::EndFrame()
 
 		glEnable( GL_TEXTURE_2D );
 
-        #ifndef __APPLE__
+		#ifndef __APPLE__
 		glBegin( GL_QUADS );
 		glTexCoord2f( 0.0f, 0.0f ); glVertex2f( -1.0f, -1.0f * -1.0f );
 		glTexCoord2f( 1.0f, 0.0f ); glVertex2f( +1.0f, -1.0f * -1.0f );
 		glTexCoord2f( 1.0f, 1.0f ); glVertex2f( +1.0f, +1.0f * -1.0f );
 		glTexCoord2f( 0.0f, 1.0f ); glVertex2f( -1.0f, +1.0f * -1.0f );
 		glEnd();
-        #endif
+		#endif
 
 		SDL_GL_SwapWindow( window_ );
 	}

--- a/src/system_window.cpp
+++ b/src/system_window.cpp
@@ -256,8 +256,10 @@ windowed:
 	viewport_size_.Width ()= static_cast<unsigned int>( width  / scale );
 	viewport_size_.Height()= static_cast<unsigned int>( height / scale );
 
+    #ifndef __APPLE__
 	use_gl_context_for_software_renderer_= !is_opengl && settings_.GetOrSetBool( "r_software_use_gl_screen_update", true );
-	if( is_opengl )
+    #endif
+    if( is_opengl )
 	{
 		SDL_GL_SetAttribute( SDL_GL_DOUBLEBUFFER, 1 );
 		SDL_GL_SetAttribute( SDL_GL_DEPTH_SIZE, 24 );
@@ -348,7 +350,9 @@ windowed:
 
 	if( is_opengl )
 	{
+        #ifndef __APPLE__
 		GetGLFunctions( SDL_GL_GetProcAddress );
+        #endif
 
 		#ifdef DEBUG
 		// Do reinterpret_cast, because on different platforms arguments of GLDEBUGPROC have
@@ -568,12 +572,14 @@ void SystemWindow::EndFrame()
 
 		glEnable( GL_TEXTURE_2D );
 
+        #ifndef __APPLE__
 		glBegin( GL_QUADS );
 		glTexCoord2f( 0.0f, 0.0f ); glVertex2f( -1.0f, -1.0f * -1.0f );
 		glTexCoord2f( 1.0f, 0.0f ); glVertex2f( +1.0f, -1.0f * -1.0f );
 		glTexCoord2f( 1.0f, 1.0f ); glVertex2f( +1.0f, +1.0f * -1.0f );
 		glTexCoord2f( 0.0f, 1.0f ); glVertex2f( -1.0f, +1.0f * -1.0f );
 		glEnd();
+        #endif
 
 		SDL_GL_SwapWindow( window_ );
 	}

--- a/src/system_window.cpp
+++ b/src/system_window.cpp
@@ -259,7 +259,7 @@ windowed:
 	#ifndef __APPLE__
 	use_gl_context_for_software_renderer_= !is_opengl && settings_.GetOrSetBool( "r_software_use_gl_screen_update", true );
 	#endif
-    if( is_opengl )
+	if( is_opengl )
 	{
 		SDL_GL_SetAttribute( SDL_GL_DOUBLEBUFFER, 1 );
 		SDL_GL_SetAttribute( SDL_GL_DEPTH_SIZE, 24 );
@@ -564,6 +564,7 @@ void SystemWindow::EndFrame()
 	}
 	else if( use_gl_context_for_software_renderer_ )
 	{
+	#ifndef __APPLE__
 		glBindTexture( GL_TEXTURE_2D, software_renderer_gl_texture_ );
 		glTexSubImage2D(
 			GL_TEXTURE_2D, 0,
@@ -572,16 +573,15 @@ void SystemWindow::EndFrame()
 
 		glEnable( GL_TEXTURE_2D );
 
-		#ifndef __APPLE__
 		glBegin( GL_QUADS );
 		glTexCoord2f( 0.0f, 0.0f ); glVertex2f( -1.0f, -1.0f * -1.0f );
 		glTexCoord2f( 1.0f, 0.0f ); glVertex2f( +1.0f, -1.0f * -1.0f );
 		glTexCoord2f( 1.0f, 1.0f ); glVertex2f( +1.0f, +1.0f * -1.0f );
 		glTexCoord2f( 0.0f, 1.0f ); glVertex2f( -1.0f, +1.0f * -1.0f );
 		glEnd();
-		#endif
 
 		SDL_GL_SwapWindow( window_ );
+	#endif
 	}
 	else
 	{


### PR DESCRIPTION
<img width="1440" alt="image" src="https://github.com/Panzerschrek/panzer_ogl_lib/assets/18221950/8435decc-ff1b-479f-8932-0cc6e17554de">

Include OpenGL 3.0 with extensions for MacOS, incompatible code fixed by macros. Tested on MacBook Air 2020 (M1)

Also need to update OpenGL library with this merge request: https://github.com/Panzerschrek/panzer_ogl_lib/pull/4