### PR TITLE
Include cstdint

### DIFF
--- a/src/net/net.hpp
+++ b/src/net/net.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include "../fwd.hpp"
 
 namespace PanzerChasm

--- a/src/rendering_context.hpp
+++ b/src/rendering_context.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <memory>
 
 #include <shaders_loading.hpp>


### PR DESCRIPTION
Include `cstdint`
to make it compile on openSUSE Tumbleweed's gcc15

Without this, it did not find definitions for `uint32_t` etc.